### PR TITLE
Improve context logic, and add package manager field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,5 +82,6 @@
     "patchedDependencies": {
       "prisma-json-types-generator": "patches/prisma-json-types-generator.patch"
     }
-  }
+  },
+  "packageManager": "pnpm@10.10.0"
 }

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -1,0 +1,14 @@
+import type express from 'express';
+import type { YogaInitialContext } from 'graphql-yoga';
+import type { SessionUser } from './user/SessionUser.tsx';
+
+export type ServerRequest = express.Request & {
+  user?: SessionUser;
+};
+
+export interface ServerContext {
+  req: ServerRequest;
+  res: express.Response;
+}
+
+export type Context = Readonly<YogaInitialContext & ServerContext>;

--- a/src/graphql/builder.tsx
+++ b/src/graphql/builder.tsx
@@ -6,9 +6,9 @@ import RelayPlugin from '@pothos/plugin-relay';
 import PrismaTypes from '../prisma/pothos-types.ts';
 import { Role } from '../prisma/prisma-client/client.ts';
 import prisma from '../prisma/prisma.tsx';
-import { Context } from './context.tsx';
 import decodeGlobalID from './lib/decodeGlobalID.tsx';
 import encodeGlobalID from './lib/encodeGlobalID.tsx';
+import { Context } from '../context.tsx';
 
 const builder = new SchemaBuilder<{
   Context: Context;

--- a/src/graphql/builder.tsx
+++ b/src/graphql/builder.tsx
@@ -3,12 +3,12 @@ import ComplexityPlugin from '@pothos/plugin-complexity';
 import DirectivePlugin from '@pothos/plugin-directives';
 import PrismaPlugin from '@pothos/plugin-prisma';
 import RelayPlugin from '@pothos/plugin-relay';
+import { Context } from '../context.tsx';
 import PrismaTypes from '../prisma/pothos-types.ts';
 import { Role } from '../prisma/prisma-client/client.ts';
 import prisma from '../prisma/prisma.tsx';
 import decodeGlobalID from './lib/decodeGlobalID.tsx';
 import encodeGlobalID from './lib/encodeGlobalID.tsx';
-import { Context } from '../context.tsx';
 
 const builder = new SchemaBuilder<{
   Context: Context;

--- a/src/graphql/context.tsx
+++ b/src/graphql/context.tsx
@@ -1,5 +1,0 @@
-import { SessionUser } from '../user/SessionUser.tsx';
-
-export type Context = Readonly<{
-  sessionUser: SessionUser;
-}>;

--- a/src/graphql/lib/addDirectives.tsx
+++ b/src/graphql/lib/addDirectives.tsx
@@ -1,8 +1,8 @@
 import { MapperKind, mapSchema } from '@graphql-tools/utils';
 import { defaultFieldResolver, GraphQLSchema } from 'graphql';
+import { Context } from '../../context.tsx';
 import { Role } from '../../prisma/prisma-client/client.ts';
 import isAdmin from '../../user/isAdmin.tsx';
-import { Context } from '../../context.tsx';
 
 export default function addDirectives(schema: GraphQLSchema) {
   return mapSchema(schema, {

--- a/src/graphql/lib/addDirectives.tsx
+++ b/src/graphql/lib/addDirectives.tsx
@@ -2,7 +2,7 @@ import { MapperKind, mapSchema } from '@graphql-tools/utils';
 import { defaultFieldResolver, GraphQLSchema } from 'graphql';
 import { Role } from '../../prisma/prisma-client/client.ts';
 import isAdmin from '../../user/isAdmin.tsx';
-import { Context } from '../context.tsx';
+import { Context } from '../../context.tsx';
 
 export default function addDirectives(schema: GraphQLSchema) {
   return mapSchema(schema, {
@@ -19,7 +19,7 @@ export default function addDirectives(schema: GraphQLSchema) {
         const role = directive?.role;
         const { resolve = defaultFieldResolver } = fieldConfig;
         fieldConfig.resolve = (source, args, context: Context, info) => {
-          const { sessionUser } = context;
+          const sessionUser = context.req.user;
           if (directiveName === 'requiresAuth') {
             if (
               !sessionUser ||

--- a/src/graphql/mutations/updateDisplayName.tsx
+++ b/src/graphql/mutations/updateDisplayName.tsx
@@ -10,7 +10,8 @@ builder.mutationField('updateDisplayName', (t) =>
     directives: {
       requiresAuth: { role: 'User' },
     },
-    resolve: async (query, _, { displayName }, { sessionUser }) => {
+    resolve: async (query, _, { displayName }, context) => {
+      const sessionUser = context.req.user;
       const user =
         sessionUser &&
         (await prisma.user.findUniqueOrThrow({
@@ -29,13 +30,13 @@ builder.mutationField('updateDisplayName', (t) =>
         throw new Error('invalid-display-name');
       }
 
-      return await prisma.user.update({
+      return prisma.user.update({
         ...query,
         data: {
           displayName,
         },
         where: {
-          id: user.id,
+          id: user?.id,
         },
       });
     },

--- a/src/graphql/nodes/User.tsx
+++ b/src/graphql/nodes/User.tsx
@@ -102,7 +102,7 @@ builder.queryFields((t) => ({
       context.req.user
         ? prisma.user.findUniqueOrThrow({
             ...query,
-          where: { id: context.req.user.id },
+            where: { id: context.req.user.id },
           })
         : void query.include,
     type: 'User',

--- a/src/graphql/nodes/User.tsx
+++ b/src/graphql/nodes/User.tsx
@@ -98,11 +98,11 @@ builder.queryFields((t) => ({
     type: 'User',
   }),
   viewer: t.prismaField({
-    resolve: (query, root, args, { sessionUser }) =>
-      sessionUser
+    resolve: (query, root, args, context) =>
+      context.req.user
         ? prisma.user.findUniqueOrThrow({
             ...query,
-            where: { id: sessionUser.id },
+          where: { id: context.req.user.id },
           })
         : void query.include,
     type: 'User',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,7 @@ import env from './lib/env.tsx';
 import prisma from './prisma/prisma.tsx';
 import installAuthMiddleware from './user/installAuthMiddleware.tsx';
 import { SessionUser } from './user/SessionUser.tsx';
+import { ServerContext } from './context.tsx';
 
 try {
   await prisma.$connect();
@@ -83,11 +84,7 @@ app.use(
   },
 );
 
-const yoga = createYoga({
-  context: (request) => ({
-    sessionUser: (request as unknown as { req: { user: SessionUser } }).req
-      .user,
-  }),
+const yoga = createYoga<ServerContext>({
   graphiql: process.env.NODE_ENV === 'development',
   schema,
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,13 +6,13 @@ import bodyParser from 'body-parser';
 import cors from 'cors';
 import express from 'express';
 import { createYoga } from 'graphql-yoga';
+import { ServerContext } from './context.tsx';
 import schema from './graphql/schema.tsx';
 import { getClientDomain, setClientDomain } from './lib/ClientDomain.tsx';
 import env from './lib/env.tsx';
 import prisma from './prisma/prisma.tsx';
 import installAuthMiddleware from './user/installAuthMiddleware.tsx';
 import { SessionUser } from './user/SessionUser.tsx';
-import { ServerContext } from './context.tsx';
 
 try {
   await prisma.$connect();


### PR DESCRIPTION
Hi @nksw-tech!
This is Arda from @the-guild-dev who are the maintainers of https://github.com/graphql-hive/graphql-yoga project!
I see this amazing template and it's using GraphQL Yoga, so I wanted to contribute :)

- Add `packageManager` field to `package.json` for `fnm`, `nvm` and `corepack` users to use the correct package manager, otherwise users with old pnpm fails
- Avoid extra context factory function, and use the server context directly to access `SessionUser`

A few notes;
- We usually recommend to avoid Node specific server frameworks like Express which also causes a performance overhead and confusion between Yoga's plugin system and the frameworks'. I didn't tackle these in this PR but I believe middlewares like auth and cors can be doable with Yoga's plugin system. https://the-guild.dev/graphql/yoga-server/docs/features/envelop-plugins
- I saw you are calling `yoga` inside the Express middleware and wrap it with try/catch but not sure if it works as expected because Yoga has its own error handling logic. https://the-guild.dev/graphql/yoga-server/docs/features/error-masking#error-codes-and-other-extensions

We'd love to help you to improve this template by removing Express and benefit from Yoga more!