### PR TITLE
Fix issue where username is not populated during admin user creation

### DIFF
--- a/src/prisma/seed.tsx
+++ b/src/prisma/seed.tsx
@@ -9,17 +9,21 @@ const prisma = new PrismaClient();
 
 const users = new Set([
   {
+    data: {
+      username: 'admin',
+    },
     email: 'admin@nakazawa.dev',
     name: 'Admin',
     password: 'not-a-secure-password',
     role: 'admin',
-    username: 'admin',
   },
   {
+    data: {
+      username: 'first-user',
+    },
     email: 'first-user@nakazawa.dev',
     name: 'First User',
     password: 'not-a-secure-password-either',
-    username: 'first-user',
   },
 ] as const);
 


### PR DESCRIPTION
## Issue

When running the seed script, the `username` field was not populated in the database.

<img width="1113" height="93" alt="image" src="https://github.com/user-attachments/assets/24d43862-1c87-4cea-aa5b-89134a0ebb7f" />

## Solution

Specify the `username` field under the `data` prop instead when calling `auth.api.createUser()`. Reference: https://www.better-auth.com/docs/plugins/admin#create-user

## Test plan

Ran updated seed script on a clean database, `username` field shows up now.

<img width="1113" height="90" alt="image" src="https://github.com/user-attachments/assets/88ac9aa7-ce88-4739-af0c-1090d3b3a55d" />
