### PR TITLE
Mention manual seed script command for setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You'll need Node.js 23+ and pnpm 10+ to use this template.
 - Run `pnpm install && pnpm generate-graphql`.
 - Set up a Postgres database locally and add the connection string to `.env` as `DATABASE_URL` or run `docker-compose up -d` to start postgres in a docker container.
 - `pnpm prisma migrate dev` to create the database, run the migrations, and seed the database.
-  - **Note**: If the database already exists, the seed script is not executed. In that case, manually run `pnpm prisma db seed`.
+  - **Note**: If the database already exists, the [seed script is not executed](https://www.prisma.io/docs/orm/prisma-migrate/workflows/seeding#integrated-seeding-with-prisma-migrate). In that case, manually run `pnpm prisma db seed`.
 - Run `pnpm dev` to start the server.
 - Open `http://localhost:9000/graphql` in your browser to see the GraphiQL, a GraphQL playground.
 - Open the Dev Tools and paste this code into the console to authenticate:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ You'll need Node.js 23+ and pnpm 10+ to use this template.
 - Start here: [Create a new app using this template](https://github.com/new?template_name=server-template&template_owner=nkzw-tech).
 - Run `pnpm install && pnpm generate-graphql`.
 - Set up a Postgres database locally and add the connection string to `.env` as `DATABASE_URL` or run `docker-compose up -d` to start postgres in a docker container.
-- `pnpm prisma migrate dev` to create the database and run the migrations.
+- `pnpm prisma migrate dev` to create the database, run the migrations, and seed the database.
+  - **Note**: If the database already exists, the seed script is not executed. In that case, manually run `pnpm prisma db seed`.
 - Run `pnpm dev` to start the server.
 - Open `http://localhost:9000/graphql` in your browser to see the GraphiQL, a GraphQL playground.
 - Open the Dev Tools and paste this code into the console to authenticate:


### PR DESCRIPTION
When testing locally (not using Docker), I tend to just delete the `public` schema and reusing existing databases. When I tried setting up for the first time yesterday, the database was empty after I ran `pnpm prisma migrate dev`. 


I was wondering why the seed script was not executed, when I thought it would. It turns out that the seed script is only executed [if a new database was created in the process](https://github.com/prisma/prisma/blob/5051cfe1e75ddf2363b7b4a82d5b9b67d6482593/packages/migrate/src/commands/MigrateDev.ts#L313).

I've added some clarifications in the README that the expectation is for data to be seeded and what to do if it's not (in my case of an existing database).