### PR TITLE
Regenerate schema.graphql

### DIFF
--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -14,7 +14,7 @@ type CaughtPokemon implements Node {
 }
 
 type Mutation {
-  updateName(name: String!): User @auth(role: "User")
+  updateName(name: String!): User @auth(role: "user")
 }
 
 interface Node {
@@ -36,10 +36,10 @@ type Pokemon implements Node {
 }
 
 type Query {
-  findUsers(after: String, before: String, first: Int, last: Int, name: String!): QueryFindUsersConnection @auth(role: "User")
+  findUsers(after: String, before: String, first: Int, last: Int, name: String!): QueryFindUsersConnection @auth(role: "user")
   node(id: ID!): Node
-  pokemon(id: ID!): Pokemon @auth(role: "User")
-  user(username: String!): User @auth(role: "User")
+  pokemon(id: ID!): Pokemon @auth(role: "user")
+  user(username: String!): User @auth(role: "user")
   viewer: User
 }
 
@@ -59,7 +59,7 @@ type User implements Node {
   id: ID!
   locale: String @auth(self: true)
   name: String!
-  role: String @auth(self: true)
+  role: String! @auth(self: true)
   username: String
 }
 


### PR DESCRIPTION
This is the newest `schema.graphql` just by running the `generate-graphql.tsx` script on the latest repo commit.

ff779f2 modified the casing of the `'user'` role but didn't regenerate `schema.graphql`.