### PR TITLE
Improve encodeID and decodeID typesafety

### DIFF
--- a/src/graphql/builder.tsx
+++ b/src/graphql/builder.tsx
@@ -53,7 +53,8 @@ const builder = new SchemaBuilder<PothosTypes>({
     clientMutationId: 'omit',
     cursorType: 'String',
     decodeGlobalID,
-    encodeGlobalID,
+    encodeGlobalID: (typename, id) =>
+      encodeGlobalID(typename as keyof PrismaTypes, id),
     nodesQueryOptions: false,
   },
   scopeAuth: {

--- a/src/graphql/lib/decodeIDOrThrow.tsx
+++ b/src/graphql/lib/decodeIDOrThrow.tsx
@@ -1,7 +1,11 @@
 import parseInteger from '@nkzw/core/parseInteger.js';
+import PrismaTypes from '../../prisma/pothos-types.ts';
 import decodeGlobalID from './decodeGlobalID.tsx';
 
-export default function decodeIDOrThrow(type: string, globalID: string) {
+export default function decodeIDOrThrow(
+  type: keyof PrismaTypes,
+  globalID: string,
+) {
   const { id, typename } = decodeGlobalID(globalID);
   const number = parseInteger(id);
   if (typename !== type || !number) {

--- a/src/graphql/lib/encodeGlobalID.tsx
+++ b/src/graphql/lib/encodeGlobalID.tsx
@@ -1,5 +1,7 @@
+import PrismaTypes from '../../prisma/pothos-types.ts';
+
 export default function encodeGlobalID(
-  typename: string,
+  typename: keyof PrismaTypes,
   id: string | number | bigint,
 ) {
   return `${typename}-${id}`;


### PR DESCRIPTION
`encodeGlobalID` is not typesafe as `typename` is defined as a string. One way to obtain the list of models is from `PrismaTypes` in the generated `prisma/pothos-types.ts`.

## Test plan

Ran `pnpm tsc:check`