### PR TITLE
Consolidate Prisma initialization within seed script

### DIFF
--- a/src/prisma/seed.tsx
+++ b/src/prisma/seed.tsx
@@ -3,9 +3,7 @@ import { styleText } from 'node:util';
 import random from '@nkzw/core/random.js';
 import { arrayToShuffled } from 'array-shuffle';
 import { auth } from '../lib/auth.tsx';
-import { PrismaClient } from './prisma-client/client.ts';
-
-const prisma = new PrismaClient();
+import prisma from './prisma.tsx';
 
 const users = new Set([
   {


### PR DESCRIPTION
Since `prisma/prisma.tsx` serves to be the initializer for `PrismaClient`, the seed file should use it too so that seeding uses the same initialization settings (e.g. if an adapter is to be used in the serverless deployment case).